### PR TITLE
Eng 650 nginx ingress support

### DIFF
--- a/charts/entando-k8s-controller-coordinator/templates/docker-image-info-configmap.yaml
+++ b/charts/entando-k8s-controller-coordinator/templates/docker-image-info-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   app-builder: >-
-    {"version":"6.1.39","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.42","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-avatar-plugin: >-
     {"version":"6.0.5","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-component-manager: >-
@@ -15,21 +15,21 @@ data:
   entando-de-app-wildfly: >-
     {"version":"6.1.23","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-app-controller: >-
-    {"version":"6.1.2","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.3","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-app-plugin-link-controller: >-
     {"version":"6.1.1","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-cluster-infrastructure-controller: >-
-    {"version":"6.1.2","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.3","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-composite-app-controller: >-
-    {"version":"6.1.2","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.3","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-controller-coordinator: >-
-    {"version":"6.1.1","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.2","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-dbjob: >-
     {"version":"6.0.36","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-keycloak-controller: >-
-    {"version":"6.1.10","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.11","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-plugin-controller: >-
-    {"version":"6.1.0","executable-type":"jvm","registry":"docker.io","organization":"entando"}
+    {"version":"6.1.1","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-k8s-service: >-
     {"version":"6.0.18","executable-type":"jvm","registry":"docker.io","organization":"entando"}
   entando-keycloak: >-

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     </scm>
     <properties>
         <github.organization>entando-k8s</github.organization>
-        <entando.k8s.operator.common.version>6.1.6</entando.k8s.operator.common.version>
+        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
         <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
     </scm>
     <properties>
         <github.organization>entando-k8s</github.organization>
-        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
-        <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
+        <entando.k8s.operator.common.version>6.1.9</entando.k8s.operator.common.version>
+        <entando.k8s.custom.model.version>6.1.5</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>

--- a/src/main/java/org/entando/kubernetes/controller/coordinator/EntandoResourceObserver.java
+++ b/src/main/java/org/entando/kubernetes/controller/coordinator/EntandoResourceObserver.java
@@ -17,9 +17,7 @@
 package org.entando.kubernetes.controller.coordinator;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import com.google.common.base.Strings;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
@@ -49,6 +47,7 @@ public class EntandoResourceObserver<
 
     public EntandoResourceObserver(CustomResourceOperationsImpl<R, L, D> operations, BiConsumer<Action, R> callback) {
         this.callback = callback;
+
         processExistingRequestedEntandoResources(operations);
         operations.watch(this);
     }


### PR DESCRIPTION
This PR brings in the latest library dependencies and images. The behaviour of the controller-coordinator itself isn't affected but it will now be able to propagate all the required state and environment variables to delegate controllers
