### PR TITLE
ENG-3515 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM entando/entando-k8s-operator-common:6.3.19
+FROM entando/entando-k8s-operator-common:6.5.0-ENG-3515-PR-104
 ARG VERSION
 
 LABEL name="Entando K8S Controller Coordinator" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.3.20</version>
+        <version>6.5.0-ENG-3515-PR-26</version>
         <relativePath/>
     </parent>
     <version>6.5.0</version>
@@ -63,7 +63,7 @@
     </scm>
     <properties>
         <github.organization>entando-k8s</github.organization>
-        <entando-k8s-operator-common.version>6.3.19</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>6.5.0-ENG-3515-PR-104</entando-k8s-operator-common.version>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>

--- a/src/test/java/org/entando/kubernetes/controller/coordinator/inprocesstests/ControllerCoordinatorMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/coordinator/inprocesstests/ControllerCoordinatorMockedTest.java
@@ -140,7 +140,7 @@ class ControllerCoordinatorMockedTest implements FluentIntegrationTesting, Fluen
                 .inNamespace(client.getNamespace()).create(keycloakServer);
         afterCreate(keycloakServer);
         //Then I expect to see at least one controller pod
-        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> listable = client.pods()
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch> listable = client.pods()
                 .inNamespace(client.getNamespace())
                 .withLabel(KubeUtils.ENTANDO_RESOURCE_KIND_LABEL_NAME, "EntandoKeycloakServer");
         await().ignoreExceptions().atMost(30, TimeUnit.SECONDS).until(() -> listable.list().getItems().size() > 0);
@@ -179,7 +179,7 @@ class ControllerCoordinatorMockedTest implements FluentIntegrationTesting, Fluen
                 .inNamespace(client.getNamespace()).create(keycloakServer);
         afterCreate(keycloakServer);
         //And I the controller pod is created.
-        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> listable = client.pods()
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch> listable = client.pods()
                 .inNamespace(client.getNamespace())
                 .withLabel(KubeUtils.ENTANDO_RESOURCE_KIND_LABEL_NAME, "EntandoKeycloakServer");
         await().ignoreExceptions().atMost(30, TimeUnit.SECONDS).until(() -> listable.list().getItems().size() > 0);

--- a/src/test/java/org/entando/kubernetes/controller/coordinator/interprocesstests/ControllerCoordinatorIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/coordinator/interprocesstests/ControllerCoordinatorIntegratedTest.java
@@ -104,7 +104,7 @@ class ControllerCoordinatorIntegratedTest implements FluentIntegrationTesting, F
     private static K8SIntegrationTestHelper helper = new K8SIntegrationTestHelper();
 
     static {
-        /* 
+        /*
          NB!!! this part is a bit convoluted. The ENTANDO_CA_SECRET_NAME JVM property could potentially be set in the
          constructor K8SIntegrationTestHelper. The init statement TestFixturePreparation.newClient() actually indirectly
          calls CertificateSecretHelper.buildCertificateSecretsFromDirectory() but only if certs could be picked up
@@ -181,7 +181,7 @@ class ControllerCoordinatorIntegratedTest implements FluentIntegrationTesting, F
                 .inNamespace(client.getNamespace()).create(keycloakServer);
 
         //Then I expect to see at least one controller pod
-        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> listable = client.pods()
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch> listable = client.pods()
                 .inNamespace(client.getNamespace())
                 .withLabel(KubeUtils.ENTANDO_RESOURCE_KIND_LABEL_NAME, "EntandoKeycloakServer");
         await().ignoreExceptions().atMost(30, TimeUnit.SECONDS).until(() -> listable.list().getItems().size() > 0);
@@ -293,7 +293,7 @@ class ControllerCoordinatorIntegratedTest implements FluentIntegrationTesting, F
                 .inNamespace(NAMESPACE)
                 .create(appToCreate);
         //Then I expect to see the keycloak controller pod
-        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> keycloakControllerList = client.pods()
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch> keycloakControllerList = client.pods()
                 .inNamespace(client.getNamespace())
                 .withLabel(KubeUtils.ENTANDO_RESOURCE_KIND_LABEL_NAME, "EntandoKeycloakServer")
                 .withLabel("EntandoKeycloakServer", app.getSpec().getComponents().get(0).getMetadata().getName());
@@ -327,7 +327,7 @@ class ControllerCoordinatorIntegratedTest implements FluentIntegrationTesting, F
                 () -> appGettable.fromServer().get().getStatus().forServerQualifiedBy(KEYCLOAK_NAME).get().getPodStatus() != null
         );
         //And the plugin controller pod
-        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> pluginControllerList = client.pods()
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch> pluginControllerList = client.pods()
                 .inNamespace(client.getNamespace())
                 .withLabel(KubeUtils.ENTANDO_RESOURCE_KIND_LABEL_NAME, "EntandoPlugin")
                 .withLabel("EntandoPlugin", app.getSpec().getComponents().get(1).getMetadata().getName());


### PR DESCRIPTION
…eta1 for the created ingresses